### PR TITLE
Fix dtype overflow in asset paths

### DIFF
--- a/prisk/asset/asset.py
+++ b/prisk/asset/asset.py
@@ -73,10 +73,10 @@ class Asset:
         self.cost_path = self.revenue_path * (1 - self._MARGIN)
         self.cyclone_protection = cyclone_protection
         self.update_expected_damage()
-        self.replacement_cost_path = np.repeat(0, self._TIME_HORIZON)
-        self.business_disruption_path = np.repeat(0, self._TIME_HORIZON)
-        self.insurance_fair_premium_path = np.repeat(0, self._TIME_HORIZON)
-        self.insurance_adjustment_path = np.repeat(0, self._TIME_HORIZON)
+        self.replacement_cost_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.business_disruption_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.insurance_fair_premium_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.insurance_adjustment_path = np.repeat(0.0, self._TIME_HORIZON)
         self.base_value = self.npv
         self.parents = []
 
@@ -135,10 +135,10 @@ class Asset:
     def reset(self) -> None:
         self.damages = np.repeat(0.0, self._TIME_HORIZON)
         self.disruptions = np.repeat(0.0, self._TIME_HORIZON)
-        self.replacement_cost_path = np.repeat(0, self._TIME_HORIZON)
-        self.business_disruption_path = np.repeat(0, self._TIME_HORIZON)
-        self.insurance_fair_premium_path = np.repeat(0, self._TIME_HORIZON)
-        self.insurance_adjustment_path = np.repeat(0, self._TIME_HORIZON)
+        self.replacement_cost_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.business_disruption_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.insurance_fair_premium_path = np.repeat(0.0, self._TIME_HORIZON)
+        self.insurance_adjustment_path = np.repeat(0.0, self._TIME_HORIZON)
         self.cost_path = self.revenue_path * (1 - self._MARGIN)
         if self._insurer:
             self.remove_insurer()


### PR DESCRIPTION
## Summary
- initialize cost paths as floating-point arrays in `Asset`
- reset cost paths with floats to avoid integer overflow

## Testing
- `python -m py_compile prisk/asset/asset.py`
- sample Asset instantiation to verify float dtypes

------
https://chatgpt.com/codex/tasks/task_e_6862531f409c8329a5a3cf414cc0776b